### PR TITLE
Articles and headlines are no longer hardcoded

### DIFF
--- a/public/data/articles.JSON
+++ b/public/data/articles.JSON
@@ -3,6 +3,7 @@
         "id": 1,
         "title": "The Top 10 Most Absurd Things That Have Happened This Year (So Far)",
         "imgsrc": "",
+        "articleType":"headline",
         "article": {
             "section": [
                 "1. The government announced that it will now be measuring time in ***dog years***.",
@@ -23,6 +24,7 @@
         "headline": "Local News",
         "title": "New Study Shows Majority of People Actually Just Pretending to Like Craft Beer",
         "imgsrc": "/images/craft-beer.png",
+        "articleType":"headline",
         "article": {
             "section": [
                 "In a shocking turn of events, a new study has revealed that the majority of people who claim to be craft beer aficionados are actually just pretending.",
@@ -37,6 +39,7 @@
         "id": 3,
         "title": "World Health Organization Announces That Stress is Actually Just a Myth",
         "imgsrc": "/images/stress.png",
+        "articleType":"headline",
         "article": {
             "section": [
                 "In a shocking announcement, the World Health Organization (WHO) has declared that stress is a myth and that people who claim to be stressed are just making it up.",
@@ -52,6 +55,7 @@
         "id": 4,
         "title": "Trump Administration Unveils Plan to Build Wall Around the Sun",
         "imgsrc": "/images/wall-around-sun.png",
+        "articleType":"headline",
         "article": {
             "section": [
                 "The Trump Administration has announced their plan to build a wall around the sun. According to White House Press Secretary Sarah Huckabee Sanders, the sun poses a threat to national security and action must be taken to protect American citizens.",
@@ -67,6 +71,7 @@
         "id": 5,
         "title": "Experts: Global Economic Collapse Just a Coincidence, Definitely Not the Result of Reckless, Short-Sighted Policies",
         "imgsrc": "",
+        "articleType":"headline",
         "article": {
             "section": [
                 "In a shocking revelation, experts have announced that the global economic collapse currently being experienced by countries around the world is just a coincidence, and definitely not the result of reckless, short-sighted policies enacted by government leaders.",
@@ -82,6 +87,7 @@
         "id": 6,
         "title": "Government Announces Plan to Replace All Forms of Communication with Emoji-Only Text Messages",
         "imgsrc": "",
+        "articleType":"headline",
         "article": {
             "section": [
                 "In a shocking move, the government has announced plans to phase out all forms of traditional communication, including verbal, written, and even sign language. The new plan, dubbed ***\"Emoji-Only,\"*** will require all citizens to communicate exclusively through a series of carefully selected emojis.",
@@ -96,6 +102,7 @@
         "id": 7,
         "title": "New Study Shows That Making the Stupid Even Stupider is Actually Possible",
         "imgsrc": "",
+        "articleType":"headline",
         "article": {
             "section": [
                 "In a groundbreaking study, researchers at the Institute of Really Obvious Things have made a shocking discovery: it is possible to make the stupid even stupider.",
@@ -112,6 +119,7 @@
         "id": 8,
         "title": "Local Man Robs Bank, Shocked to Find Out It's Illegal",
         "imgsrc": "",
+        "articleType":"local",
         "article": {
             "section": [
                 "In a shocking turn of events, local man Jeffery Thompson found out the hard way that robbing a bank is actually illegal. Thompson, who had always assumed that banks were just giant piggy banks full of free money, was completely taken aback when police officers arrived on the scene and arrested him.",
@@ -126,6 +134,7 @@
         "id": 9,
         "title": "Man Thinks SWAT Team Raiding His Home is Actually a Surprise Birthday Party, Gets Tased and Handcuffed",
         "imgsrc": "",
+        "articleType":"local",
         "article": {
             "section": [
                 "In a shocking turn of events, local man Tim Johnson was left stunned when he woke up to a SWAT team raiding his home early this morning. Thinking it was a surprise birthday party organized by his loved ones, Tim opened the door with a smile on his face, only to be met with a barrage of tasers and handcuffs.",
@@ -140,6 +149,7 @@
         "id": 10,
         "title": "Outraged Man Demands to See Manager After Learning It's Actually Illegal to Steal From Local Pharmacy",
         "imgsrc": "",
+        "articleType":"local",
         "article": {
             "section": [
                 "The scene was chaotic and absurd, as if something straight out of a comedy sketch. Local man, Tom Jenkins, was livid. He had just learned that it was actually illegal to steal from the local pharmacy, and he was not happy about it.",
@@ -155,6 +165,7 @@
         "id": 11,
         "title": "Local Shops Embrace the Future by Replacing Employees with Robots: \"They Never Complain and They Don't Need Breaks\"",
         "imgsrc": "",
+        "articleType":"local",
         "article": {
             "section": [
                 "In a shocking turn of events, local shops across the country are embracing the future by replacing their employees with robots. According to shop owners, the decision was a no-brainer.",
@@ -170,6 +181,7 @@
         "id": 12,
         "title": "Local Man Brags About Being \"Isekai'd\" into Fantasy World, Returns with Terrible Manuscript and No Marketable Skills",
         "imgsrc": "",
+        "articleType":"local",
         "article": {
             "section": [
                 "Local man, Tim Johnson, is causing quite the stir in his small town. After claiming to have been ***\"isekai'd\"*** into a fantasy world, he returned with a manuscript of his supposed adventures and has been trying to sell it to anyone who will listen.",
@@ -186,6 +198,7 @@
         "id": 13,
         "title": "Man Loses Life Savings at Casino, Calls it \"Smart Financial Move\" and Demands to See Manager",
         "imgsrc": "",
+        "articleType":"local",
         "article": {
             "section": [
                 "Local man, John Doe, is making headlines today for his outrageous behavior at the downtown casino. After losing his entire life savings at the slot machines, Doe marched up to the manager's office and demanded a refund.",

--- a/src/Components/Home/Headlines/Headlines.css
+++ b/src/Components/Home/Headlines/Headlines.css
@@ -1,26 +1,32 @@
-
-.home .headlines ul li, .home .local ul li{
+.home .headlines ul li,
+.home .local ul li {
     font-weight: bold;
     list-style-type: none;
 }
 
-.home .headlines h3{
+.home .headlines ul li li {
+    font-weight: normal;
+    list-style-type: decimal;
+}
+
+.home .headlines h3 {
     text-align: center;
 }
 
-.home .headlines ul p{
+.home .headlines ul li p {
     font-size: 1.2rem;
     line-height: 1.5rem;
     margin-left: 1vw;
+    font-weight: normal;
 }
 
-.home .headlines{
+.home .headlines {
     max-width: 47vw;
 }
 
 @media only screen and (max-width: 944px) {
-    .home .headlines{
+    .home .headlines {
         max-width: 90vw;
     }
-    
+
 }

--- a/src/Components/Home/Headlines/Headlines.js
+++ b/src/Components/Home/Headlines/Headlines.js
@@ -1,52 +1,30 @@
 import { Link } from "react-router-dom";
 import './Headlines.css';
-const Headlines = () => {
+import ReactMarkdown from "react-markdown";
+const Headlines = (props) => {
+
+    const headlineArticles = props.data.filter((element) => {
+        return element.articleType === 'headline';
+    });
     const handleClick = () => {
-        window.scrollTo(0,0);
+        window.scrollTo(0, 0);
     }
 
     return (
-            <section className='headlines'>
-                <h3>Latest Headlines</h3>
-                <ul>
-                    <li><Link to="/article-2" onClick={handleClick} className='link'>New Study Shows Majority of People Actually Just Pretending to Like Craft Beer</Link></li>
-                    <p>Are You Really a Craft Beer Fan, or Just Pretending?<br />
-                        A new study has found that the majority of people who claim to enjoy craft beer are actually<br />
-                        just pretending.
-                    </p>
-                    <li><Link to="/article-3" onClick={handleClick} className='link'>World Health Organization Announces That Stress is Actually Just a Myth</Link></li>
-                    <p>
-                        "We have come to the conclusion that stress does not exist," said Dr. Maria Hernandez,<br />
-                        a spokesperson for the WHO.
-                    </p>
-                    <li><Link to="/article-4" onClick={handleClick} className='link'>Trump Administration Unveils Plan to Build Wall Around the Sun</Link></li>
-                    <p>
-                        "The sun is a threat to our national security, and we must take action to protect our citizens,"<br />
-                        said White House Press Secretary Sarah Huckabee Sanders. "This wall will be the most <br />
-                        advanced solar defense system in the world, and it will make America great again."
-                    </p>
-                    <li><Link to="/article-5" onClick={handleClick} className='link' >Experts: Global Economic Collapse Just a Coincidence, Definitely Not the Result of Reckless, Short-Sighted Policies</Link></li>
-                    <p>
-                        According to leading economist Dr. John Smith, the collapse is simply a "random <br />
-                        occurrence" and has nothing to do with the fact that governments have been printing <br />
-                        unlimited amounts of money, leading to skyrocketing inflation and the devaluation of <br />
-                        currencies.
-                    </p>
-                    <li><Link to="/article-6" onClick={handleClick} className='link'>Government Announces Plan to Replace All Forms of Communication with Emoji-Only Text Messages</Link></li>
-                    <p>
-                        "In a shocking move, the government has announced plans to phase out all forms of traditional <br/>
-                        communication, including verbal, written, and even sign language.The new plan, dubbed "Emoji-Only,"
-                         will require all citizens to communicate exclusively through a series of carefully selected emojis.
-                    </p>
-                    <li><Link to="/article-7" onClick={handleClick} className="link">New Study Shows That Making the Stupid Even Stupider is Actually Possible</Link></li>
-                    <p>
-                        In a shocking new discovery, scientists have found a way to make the stupid even stupider. <br/>
-                        In a groundbreaking study, researchers at the Institute of Really Obvious Things found that <br/>
-                        by exposing the already dim-witted to even more idiotic stimuli, their intelligence levels <br/>
-                        could be drastically reduced.
-                    </p>
-                </ul>
-            </section>
+        <section className='headlines'>
+            <h3>Latest Headlines</h3>
+            <ul>
+                {
+                    headlineArticles.map((element, index) => {
+                        return <li key={index}>
+                                <Link to={`/article-${element.id}`} onClick={handleClick} className='link'>{element.title}</Link>
+                                <ReactMarkdown>{element.article.section[0].substring(0,150) + "..."}</ReactMarkdown>
+                                <br></br>
+                            </li>
+                    })
+                }
+            </ul>
+        </section>
     );
 }
 

--- a/src/Components/Home/Home.js
+++ b/src/Components/Home/Home.js
@@ -12,8 +12,8 @@ const Home = (props) => {
             <Header quote={props.quote}/>
             <MainNav data={props.data}/>
             <section className="home">
-                <Headlines />
-                <Local />
+                <Headlines data={props.data}/>
+                <Local data={props.data}/>
             </section>
         </div>
     );

--- a/src/Components/Home/Local/Local.js
+++ b/src/Components/Home/Local/Local.js
@@ -1,26 +1,25 @@
 import './Local.css';
 import { Link } from 'react-router-dom';
-const Local = () =>{
-
+const Local = (props) => {
+    const localArticles = props.data.filter((element) => {
+        return element.articleType === 'local';
+    });
     const handleClick = () => {
-        window.scrollTo(0,0);
+        window.scrollTo(0, 0);
     }
-    return(
+    return (
         <section className="local">
             <h4>Local</h4>
             <ul>
-                <li><Link to='article-8' onClick={handleClick} className='link'>Local Man Robs Bank, Shocked to Find Out It's Illegal</Link></li>
-                <br/>
-                <li><Link to='article-9' onClick={handleClick} className='link'>Man Thinks SWAT Team Raiding His Home is Actually a Surprise Birthday Party, Gets Tased and Handcuffed</Link></li>
-                <br/>
-                <li><Link to='article-10' onClick={handleClick} className='link'>Outraged Man Demands to See Manager After Learning It's Actually Illegal to Steal From Local Pharmacy</Link></li>
-                <br/>
-                <li><Link to='article-11' onClick={handleClick} className='link'>Local Shops Embrace the Future by Replacing Employees with Robots: "They Never Complain and They Don't Need Breaks"</Link></li>
-                <br/>
-                <li><Link to='article-12' onClick={handleClick} className='link'>Local Man Brags About Being 'Isekai'd' into Fantasy World, Returns with Terrible Manuscript and No Marketable Skills</Link></li>
-                <br/>
-                <li><Link to='article-13' onClick={handleClick} className='link'>Man Loses Life Savings at Casino, Calls it 'Smart Financial Move' and Demands to See Manager</Link></li>
-                <br/>
+                {
+                    localArticles.map((element, index) => {
+                        return <li key={index}>
+                            <Link to={`article-${element.id}`} onClick={handleClick} className='link'>{element.title}</Link>
+                            <p></p>
+                            <br/>
+                        </li>
+                    })
+                }
             </ul>
         </section>
     );


### PR DESCRIPTION
A long time ago articles and headlines were written directly into the components.
Now those components rely on the data from the JSON file. data is now dynamic and means that any updates according to such as additional articles and headlines will be automatically added to the list. No need to re assign and order them how i see fit. it just needs to be pulled from a filter of desired datasets that has an articleType identifier.